### PR TITLE
fix: Provide the ability to disable the writing of the comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ See a more complete example in [examples](examples/.github/workflows/notebook-re
     mynotebook.ipynb,somedir/another_notebook.pynb. It is expected that this is
     the output from an action like [dorny/paths-filter][path-filter].
 
+-   `add_comment` - (Optional) By default the action will attempt to write a
+    comment to the open PR or issue that triggered this action. This flag allows 
+    workflows that are triggered on direct push to a branch to disable this behavior.
+
 
 [bucket]: https://cloud.google.com/storage/docs/creating-buckets
 [auth]: https://github.com/google-github-actions/auth

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Google Cloud region e.g. us-central1, us-east4'
     default: 'us-central1'
     required: false
+  add_comment:
+    description: 'Add a comment to an open PR as the final step - defaults to "true"'
+    default: 'true'
+    required: false
 
 runs:
   using: 'composite'
@@ -103,10 +107,14 @@ runs:
         vertex_job_uri: 'https://console.cloud.google.com/vertex-ai/locations'
         vertex_notebook_uri: 'https://notebooks.cloud.google.com/view'
         region: '${{ inputs.region }}'
+        add_comment: '${{ inputs.add_comment }}'
       uses: 'actions/github-script@9ac08808f993958e9de277fe43a64532a609130e'
       with:
         script: |
           try {
+            if (process.env.add_comment.toLowerCase() !== 'true') {
+              return;
+            }
             const fs = require('fs');
 
             const region = process.env.region;


### PR DESCRIPTION
Workflows that are triggered by a direct push to 'main' fail when using the action because there is no pull request to write the comment to.

