### PR TITLE
fix: updated example workflow to perform a checkout

### DIFF
--- a/examples/.github/workflows/notebook-review.yml
+++ b/examples/.github/workflows/notebook-review.yml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - id: 'checkout'
+      uses: 'actions/checkout@v3'
     # Configure Workload Identity Federation and generate an access token.
     - id: 'auth'
       name: 'Authenticate to Google Cloud'


### PR DESCRIPTION
The current example was missing a step that called `actions/checkout` which caused the `run-vertexai-notebook` action to fail since it could not find any of the source files.

This fixes #20 
