### PR TITLE
fix: input name for the kernel parameter was not referenced correctly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         source_location: 'gs://${{ inputs.gcs_source_bucket }}'
         machine_type: '${{ inputs.vertex_machine_type }}'
         region: '${{ inputs.region }}'
-        kernel: '${{ inputs.kernel }}'
+        kernel: '${{ inputs.kernel_name }}'
         container: '${{ inputs.vertex_container_name }}'
       run: |-
         set -x;


### PR DESCRIPTION
The parameter name did not match in the input value that was used in the step.

Fixes #22 
